### PR TITLE
feat: add StorageClasses creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ No modules.
 | <a name="input_service_account_create"></a> [service\_account\_create](#input\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The k8s EBS CSI driver service account name | `string` | `"aws-ebs-csi-driver"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional helm sets which will be passed to the Helm chart values, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/charts/aws-ebs-csi-driver | `map(any)` | `{}` | no |
+| <a name="input_storage_classes"></a> [storage\_classes](#input\_storage\_classes) | List of the custom Storage Classes definitions | `list` | <pre>[<br>  {<br>    "allowVolumeExpansion": true,<br>    "annotations": {<br>      "storageclass.kubernetes.io/is-default-class": "true"<br>    },<br>    "name": "ebs-csi-gp3",<br>    "parameters": {<br>      "encrypted": "true",<br>      "type": "gp3"<br>    },<br>    "reclaimPolicy": "Delete",<br>    "volumeBindingMode": "WaitForFirstConsumer"<br>  }<br>]</pre> | no |
+| <a name="input_storage_classes_create"></a> [storage\_classes\_create](#input\_storage\_classes\_create) | Whether to create Storage Classes | `bool` | `true` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/charts/aws-ebs-csi-driver | `string` | `""` | no |
 
 ## Outputs

--- a/values.tf
+++ b/values.tf
@@ -18,6 +18,7 @@ locals {
         }
       }
     }
+    "storageClasses" : var.storage_classes_create ? var.storage_classes : []
   })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,31 @@ variable "irsa_tags" {
   description = "IRSA resources tags"
 }
 
+variable "storage_classes_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Storage Classes"
+}
+
+variable "storage_classes" {
+  default = [
+    {
+      "name" : "ebs-csi-gp3"
+      "annotations" : {
+        "storageclass.kubernetes.io/is-default-class" : "true"
+      }
+      "allowVolumeExpansion" : true
+      "volumeBindingMode" : "WaitForFirstConsumer"
+      "reclaimPolicy" : "Delete"
+      "parameters" : {
+        "type" : "gp3"
+        "encrypted" : "true"
+      }
+    }
+  ]
+  description = "List of the custom Storage Classes definitions"
+}
+
 variable "argo_namespace" {
   type        = string
   default     = "argo"


### PR DESCRIPTION
# Description

Add option to create StorageClass resource in EKS cluster (`enabled` by default)

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

deployed into EKS cluster and tested on [official examples of dynamic volume provisioning](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/dynamic-provisioning)
