### PR TITLE
refactor: Update to the EBS CSI Driver IAM Policy for AWS 2025 changes

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -60,6 +60,16 @@ data "aws_iam_policy_document" "this" {
   }
 
   statement {
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:ec2:*:*:snapshot/*",
+    ]
+
+    actions = ["ec2:CreateVolume"]
+  }
+
+  statement {
     effect    = "Allow"
     resources = ["*"]
     actions   = ["ec2:CreateVolume"]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2190

> In January of 2025, AWS will change the handling of IAM polices authorizing the CreateVolume action. Previously, only the created volume was authorized when using CreateVolume to restore a snapshot. After the change, the snapshot being restored will also be authorized. Because of this change, the policy being used for the EBS CSI Driver must grant explicit access to the snapshot being restored.
>
> If no action is taken before the change takes place, the EBS CSI Driver will be unable to restore snapshots when creating a volume.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [x] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
